### PR TITLE
Add openedx domain to matomo-production.js

### DIFF
--- a/scripts/matomo-production.js
+++ b/scripts/matomo-production.js
@@ -1,6 +1,6 @@
   var _paq = _paq || [];
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-  _paq.push(["setDomains", ["*.learn.up2university.eu","*.cernbox.up2university.eu","*.eduoer.up2university.eu","*.lrs.up2university.eu","*.oc.up2university.eu","*.repo.up2university.eu","*.selcont.up2university.eu","*.swan.up2university.eu","*.vc.up2university.eu","*.cs.up2university.eu","*.poddium.eu","*.sso.up2university.eu"]]);
+  _paq.push(["setDomains", ["*.learn.up2university.eu","*.cernbox.up2university.eu","*.eduoer.up2university.eu","*.lrs.up2university.eu","*.oc.up2university.eu","*.repo.up2university.eu","*.selcont.up2university.eu","*.swan.up2university.eu","*.vc.up2university.eu","*.cs.up2university.eu","*.poddium.eu","*.sso.up2university.eu","*.openedx-up2u.teltek.es"]]);
   _paq.push(["enableCrossDomainLinking"]);
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);


### PR DESCRIPTION
I'd like to have OpenEdX tracked by Matomo too. The instance is at openedx-up2u.teltek.es. Is this the only change needed, or do we have to configure anything more?